### PR TITLE
Start making changes to make this a standalone repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How to contribute
 
 We welcome contributions from external contributors, and this document
-describes how to merge code changes into this qcportal. 
+describes how to merge code changes into QCPortal. 
 
 ## Getting Started
 
@@ -13,6 +13,9 @@ describes how to merge code changes into this qcportal.
 
 ## Making Changes
 
+* Unique to QCPortal: This repository is partially maintained by an automated pipeline
+  where the `qcportal` directory is maintained through the [QCFractal](github.com/MolSSI/QCFRactal)
+  repository. Main code changes should be made there.
 * Add some really awesome code to your local fork.  It's usually a [good
   idea](http://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)
   to make changes on a

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,9 @@ Notable points that this PR has either accomplished or will accomplish.
   - [ ] TODO 1
 
 ## Questions
-- [ ] Question1
+Outstanding questions with respect to this PR
+- [ ] Question 1 
 
 ## Status
 - [ ] Ready to go
+- [ ] **CRITICAL:** This PR Does *not* modify the `qcportal` directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ matrix:
     - os: osx
       language: generic
       env: PYTHON_VER=3.6
+    - os: osx
+      language: generic
+      env: PYTHON_VER=3.7
 
     - os: linux
       python: 3.5
@@ -19,6 +22,10 @@ matrix:
     - os: linux
       python: 3.6
       env: PYTHON_VER=3.6
+    - os: linux
+      python: 3.7
+      env: PYTHON_VER=3.7
+
 
 before_install:
     # Additional info about the build

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ matrix:
     - os: linux
       python: 3.7
       env: PYTHON_VER=3.7
-      dist: xenial
+  allow_failures:
+    - env: PYTHON_VER=3.7
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
     - os: linux
       python: 3.7
       env: PYTHON_VER=3.7
+      dist: xenial
 
 
 before_install:

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 
-Copyright 2018 MolSSI
+Copyright 2018, The Molecular Sciences Software Institute
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 following conditions are met:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,28 @@
 QCPortal
 ==============================
 [//]: # (Badges)
-[![Travis Build Status](https://travis-ci.org/REPLACE_WITH_OWNER_ACCOUNT/QCPortal.png)](https://travis-ci.org/REPLACE_WITH_OWNER_ACCOUNT/QCPortal)
+[![Travis Build Status](https://travis-ci.org/molssi/QCPortal.png)](https://travis-ci.org/REPLACE_WITH_OWNER_ACCOUNT/QCPortal)
 [![codecov](https://codecov.io/gh/REPLACE_WITH_OWNER_ACCOUNT/QCPortal/branch/master/graph/badge.svg)](https://codecov.io/gh/REPLACE_WITH_OWNER_ACCOUNT/QCPortal/branch/master)
 
-A client interface to the QC Archive Project
+A client interface to the QC Archive Project.
+
+This standalone client serves to hook into QCFractal instances from remote or local 
+locations and is designed for end-users who which to access the QCFractal stores.
+
+The main source code for this project is automatically ported over from the 
+[QCFractal](https://github.com/molssi/qcfractal) automatically. Issues involving 
+the source code itself (anything in the `qcfractal` directory) should raise an issue 
+on the [QCFractal issue tracker](https://github.com/MolSSI/QCFractal/issues/new/choose) 
+for the `interface`. Issues about the documentation, repository structure, or deployment 
+of the standalone QCPortal can be raised on this repository. 
 
 ### Copyright
 
-Copyright (c) 2018, MolSSI
+Copyright (c) 2018, Molecular Software Sciences Institute (MolSSI)  
 
 
 #### Acknowledgements
  
 Project based on the 
 [Computational Chemistry Python Cookiecutter](https://github.com/choderalab/cookiecutter-python-comp-chem)
+

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -15,6 +15,12 @@ requirements:
 
   run:
     - python
+    - numpy
+    - pandas
+    - pytest
+    - jsonschema
+    - requests
+    - pyyaml
 
 test:
   requires:
@@ -23,5 +29,5 @@ test:
     - qcportal
 
 about:
-  home: add_url_here
+  home: https://github.com/molssi/qcportal/
   license: BSD-3-Clause License

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 QCPortal
 A client interface to the QC Archive Project
 """
-from setuptools import setup
+from setuptools import setup, find_packages
 import versioneer
 
 DOCLINES = __doc__.split("\n")
@@ -16,27 +16,29 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     license='BSD-3-Clause',
-
     # Which Python importable modules should be included when your package is installed
-    packages=['qcportal', "qcportal.tests"],
+    packages=find_packages(),
 
-    # Optional include package data to ship with your package
-    # Comment out this line to prevent the files from being packaged with your software
-    # Extend/modify the list to include/exclude other items as need be
-    package_data={'qcportal': ["data/*.dat"]
-                  },
+    install_requires=[
+        'numpy>=1.7',
+        'pandas',
+        'pytest',
+        'jsonschema',
+        'requests',
+        'pyyaml',
+    ],
 
-    # Additional entries you may want simply uncomment the lines you want and fill in the data
-    # author_email='me@place.org',      # Author email
-    # url='http://www.my_package.com',  # Website
-    # install_requires=[],              # Required packages, pulls from pip if needed; do not use for Conda deployment
-    # platforms=['Linux',
-    #            'Mac OS-X',
-    #            'Unix',
-    #            'Windows'],            # Valid platforms your code works on, adjust to your flavor
-    # python_requires=">=3.5",          # Python version restrictions
+    tests_require=[
+        'pytest',
+        'pytest-cov',
+    ],
+
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Science/Research',
+        'Programming Language :: Python :: 3',
+    ],
 
     # Manual control if final package is compressible or not, set False to prevent the .egg from being made
-    # zip_safe=False,
-
+    zip_safe=True,
 )


### PR DESCRIPTION
This changes the top level of the repository to make it behave more like a standalone repo,
while still being compatible with the auto updates which come in from the pipeline to the main source code.

Gets travis working, tests, and some basic documentation. There will likely be more that comes later, but this is some of the core requirements we will need to tackle eventually anyways.

Also introduces some changes to the PR template, adding a check mark that PR's do not try to change the source code.

Depends on MolSSI/QCFractal#56 to get the test imports working correctly.

Once more, with feeling, after #1 and #2 failed miserably

- [x] Ready to go