### PR TITLE
Update setup.py for the 0.7+ changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,9 @@ setup(
         'requests',
         'pyyaml',
         'pydantic>=0.20',
-        'qcelemental>=0.3.3'
+        'qcelemental>=0.4.0',
+        'plotly',
+        'py3dmol'
     ],
 
     tests_require=[


### PR DESCRIPTION
## Description
I noticed we had not updated the setup.py for qcportal in a bit. This corrects that issue

## Status
- [x] Ready to go
- [x] **CRITICAL:** This PR Does *not* modify the `qcportal` directory