### PR TITLE
QCPortal: Allow Datasets to run compute with properties driver

### DIFF
--- a/qcportal/collections/dataset.py
+++ b/qcportal/collections/dataset.py
@@ -1289,7 +1289,7 @@ class Dataset(Collection):
         driver: str
             The driver for the collection computation.
         """
-        self.data__dict__["default_driver"] = driver
+        self.data.__dict__["default_driver"] = driver
         return True
 
     def add_keywords(self, alias: str, program: str, keyword: "KeywordSet", default: bool = False) -> bool:

--- a/qcportal/collections/dataset.py
+++ b/qcportal/collections/dataset.py
@@ -700,7 +700,7 @@ class Dataset(Collection):
         DataFrame
             A DataFrame of the queried parameters
         """
-        au_units = {"energy": "hartree", "gradient": "hartree/bohr", "hessian": "hartree/bohr**2"}
+        au_units = {"energy": "hartree", "gradient": "hartree/bohr", "hessian": "hartree/bohr**2","properties":"hartree"}
 
         # So that datasets with no records do not require a default program and default keywords
         if len(self.list_records()) == 0:

--- a/qcportal/collections/dataset.py
+++ b/qcportal/collections/dataset.py
@@ -1278,6 +1278,17 @@ class Dataset(Collection):
 
         self.data.__dict__["default_benchmark"] = benchmark
         return True
+    def set_default_driver(self,driver: str) -> bool:
+        """
+        Sets the default driver value.
+
+        Parameters
+        ----------
+        driver: str
+            The driver for the collection computation.
+        """
+        self.data__dict__["default_driver"] = driver
+        return True
 
     def add_keywords(self, alias: str, program: str, keyword: "KeywordSet", default: bool = False) -> bool:
         """


### PR DESCRIPTION
## Description
This PR allows Datasets to run compute with the properties driver.  To do this I added a set_default_driver function to collections/dataset.py.  I did this because ds.data.default_driver is immutable, rather the Datamodel is immutable.  The reason I added this function was because I wasn't clear on how to set up a Dataset with a default driver other than energy.  I wanted to run calculations with the properties driver. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] It's possible to run compute with the different drivers.

## Questions
Outstanding questions with respect to this PR
- [ ] I'm not sure having the ability to change the default driver is a good idea. 

## Status
- [ ] Ready to go
- [ ] **CRITICAL:** This PR Does *not* modify the `qcportal` directory