### PR TITLE
Replace curl with wget in travis

### DIFF
--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -13,8 +13,8 @@ else
     MINICONDA=Miniconda3-latest-Linux-x86_64.sh
 fi
 MINICONDA_HOME=$HOME/miniconda
-MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
-wget -q https://repo.continuum.io/miniconda/$MINICONDA
+MINICONDA_MD5=$(wget -qO- https://repo.anaconda.com/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+wget -q https://repo.anaconda.com/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     echo "Miniconda MD5 mismatch"
     exit 1


### PR DESCRIPTION
Curl seems to be having a problem with some redirects on
continuum.io. Changing the URL to anaconda.com seems to
work, at least for now.

This affects the MD5 test of the downloaded miniconda environment,
causing all travis builds to fail.

I also change the curl command to wget to make it consistent with
how the file itself is retrieved.

## Status
- [x] Ready to go
- [X] **CRITICAL:** This PR Does *not* modify the `qcportal` directory
