### PR TITLE
Remove python 3.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         environ: [base]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     long_description_content_type="text/markdown",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
+    python_requires=">=3.7",
     license='BSD-3-Clause',
     # Which Python importable modules should be included when your package is installed
     packages=find_packages(),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- WARNING! All pull requests that modify the qcportal folder *must* happen on github.com/MolSSI/QCFractal -->
<!-- QCPortal is derived from the QCFractal/interface folder! -->

## Description
Remove python 3.6 from CI and setup.py. Everything is moving to 3.7+

## Status
- [X] Ready to go
- [X] **CRITICAL:** This PR Does *not* modify the `qcportal` directory
